### PR TITLE
Fix misleading error when API token is invalid

### DIFF
--- a/cac_jira/__init__.py
+++ b/cac_jira/__init__.py
@@ -73,7 +73,7 @@ def _initialize():
         _module_state["JIRA_CLIENT"] = client.JiraClient(
             jira_server, jira_username, jira_api_token
         )
-    except RuntimeError as e:
+    except client.JiraAuthenticationError as e:
         log.error("%s", e)
         sys.exit(1)
     _initialized = True

--- a/cac_jira/__init__.py
+++ b/cac_jira/__init__.py
@@ -69,9 +69,13 @@ def _initialize():
         sys.exit(1)
 
     _module_state["CONFIG"] = config
-    _module_state["JIRA_CLIENT"] = client.JiraClient(
-        jira_server, jira_username, jira_api_token
-    )
+    try:
+        _module_state["JIRA_CLIENT"] = client.JiraClient(
+            jira_server, jira_username, jira_api_token
+        )
+    except RuntimeError as e:
+        log.error("%s", e)
+        sys.exit(1)
     _initialized = True
 
 

--- a/cac_jira/core/client.py
+++ b/cac_jira/core/client.py
@@ -12,6 +12,10 @@ from jira.exceptions import JIRAError
 log = cac.logger.new(__name__)
 
 
+class JiraAuthenticationError(Exception):
+    pass
+
+
 class JiraClient:
     """
     Jira client class.
@@ -51,7 +55,7 @@ class JiraClient:
                 else ""
             )
             if login_reason == "AUTHENTICATED_FAILED":
-                raise RuntimeError(
+                raise JiraAuthenticationError(
                     "Authentication failed — your API token may be invalid or expired. "
                     "Regenerate it at https://id.atlassian.com/manage-profile/security/api-tokens"
                 ) from e

--- a/cac_jira/core/client.py
+++ b/cac_jira/core/client.py
@@ -7,6 +7,7 @@ Jira client module.
 
 import cac_core as cac
 import jira
+from jira.exceptions import JIRAError
 
 log = cac.logger.new(__name__)
 
@@ -41,6 +42,21 @@ class JiraClient:
                 f"https://{self.server}",
                 basic_auth=(self.username, self.api_token),
             )
+            self.client.myself()
+        except JIRAError as e:
+            response = getattr(e, "response", None)
+            login_reason = (
+                getattr(response, "headers", {}).get("X-Seraph-Loginreason", "")
+                if response is not None
+                else ""
+            )
+            if login_reason == "AUTHENTICATED_FAILED":
+                raise RuntimeError(
+                    "Authentication failed — your API token may be invalid or expired. "
+                    "Regenerate it at https://id.atlassian.com/manage-profile/security/api-tokens"
+                ) from e
+            log.error("Failed to connect to Jira server: %s", e)
+            raise
         except Exception as e:
             log.error("Failed to connect to Jira server: %s", e)
             raise

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,54 @@
+"""
+Tests for JiraClient authentication handling.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from jira.exceptions import JIRAError
+
+from cac_jira.core.client import JiraAuthenticationError, JiraClient
+
+
+def _make_auth_failure():
+    """Create a JIRAError that simulates Jira's auth-failed-as-404 response."""
+    response = MagicMock()
+    response.headers = {"X-Seraph-Loginreason": "AUTHENTICATED_FAILED"}
+    return JIRAError(
+        status_code=404,
+        text="No project could be found with key 'TEST'.",
+        response=response,
+    )
+
+
+@patch("jira.JIRA")
+class TestJiraClientAuth:
+    def test_auth_failure_raises_authentication_error(self, mock_jira_class):
+        mock_client = MagicMock()
+        mock_client.myself.side_effect = _make_auth_failure()
+        mock_jira_class.return_value = mock_client
+
+        with pytest.raises(JiraAuthenticationError, match="API token may be invalid"):
+            JiraClient("test.atlassian.net", "user@example.com", "bad-token")
+
+    def test_non_auth_jira_error_propagates(self, mock_jira_class):
+        mock_client = MagicMock()
+        response = MagicMock()
+        response.headers = {"X-Seraph-Loginreason": "OK"}
+        mock_client.myself.side_effect = JIRAError(
+            status_code=500, text="Server error", response=response
+        )
+        mock_jira_class.return_value = mock_client
+
+        with pytest.raises(JIRAError):
+            JiraClient("test.atlassian.net", "user@example.com", "token")
+
+    def test_successful_connect(self, mock_jira_class):
+        mock_client = MagicMock()
+        mock_client.myself.return_value = {"accountId": "123"}
+        mock_jira_class.return_value = mock_client
+
+        client = JiraClient("test.atlassian.net", "user@example.com", "good-token")
+
+        assert client.client is mock_client
+        mock_client.myself.assert_called_once()


### PR DESCRIPTION
## Summary
- Jira returns HTTP 404 (not 401) when authentication fails, which caused the CLI to report "Failed to find project" for what is actually a credentials issue
- Added an auth validation call (`myself()`) at connect time in `JiraClient` to catch invalid/expired tokens early
- Surfaces a clear error message with a link to regenerate the API token

## Test plan
- [x] Run `jira issue create` with an expired/invalid API token and verify the new error message appears
- [x] Run `jira issue create` with valid credentials and verify normal operation is unaffected
- [x] Run existing test suite (`uv run pytest`)