### PR TITLE
chore: adopt cac-core 1.0.0 and refresh CI actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned SHAs current
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:13"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Keep Python dependencies (uv / pyproject.toml + uv.lock) current
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:13"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/create_artifacts_and_publish.yaml
+++ b/.github/workflows/create_artifacts_and_publish.yaml
@@ -18,8 +18,8 @@ jobs:
       id-token: write # to mint OIDC token for attestation
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -29,11 +29,11 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Attest generated files
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v2
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/
       - name: Upload release distributions
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-dists
           path: dist/
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,11 +16,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # required for setuptools-scm to resolve version from tags
       - name: Install uv
-        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Check lock file is up to date

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ uv run pytest                  # Run all tests
 uv run pytest tests/test_cli.py  # Run a single test file
 
 # Linting & Formatting
-ruff check --target-version=py39 .   # Lint
+ruff check --target-version=py310 .   # Lint
 ruff format --diff .                  # Check formatting
 
 # Type checking
@@ -72,13 +72,13 @@ Each action must implement two abstract methods: `define_arguments(parser)` and 
 
 ## Code Style
 
-- Python >=3.10 required (CI tests 3.9–3.12)
+- Python >=3.10 required (CI tests 3.10–3.12)
 - Black formatting with 88-char line length
 - isort with black-compatible profile
 - Output formatting uses `cac_core.output.Output` (supports table and JSON formats)
 
 ## CI/CD
 
-- PRs require a version bump in `pyproject.toml` (enforced by `version-check.yaml`)
-- Tests run on push and PR across Python 3.9–3.12
-- Releases triggered by version tags (v*), published to PyPI
+- Version is derived from git tags via `setuptools-scm` (no static version in `pyproject.toml`); no per-PR version bump is required
+- Tests run on push and PR across Python 3.10–3.12 (`pytest.yaml`)
+- Releases triggered by version tags (v*), published to PyPI (`create_artifacts_and_publish.yaml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Each action must implement two abstract methods: `define_arguments(parser)` and 
 
 ## Code Style
 
-- Python >=3.10 required (CI tests 3.10–3.12)
+- Python >=3.10 required (CI tests 3.10–3.14)
 - Black formatting with 88-char line length
 - isort with black-compatible profile
 - Output formatting uses `cac_core.output.Output` (supports table and JSON formats)
@@ -80,5 +80,5 @@ Each action must implement two abstract methods: `define_arguments(parser)` and 
 ## CI/CD
 
 - Version is derived from git tags via `setuptools-scm` (no static version in `pyproject.toml`); no per-PR version bump is required
-- Tests run on push and PR across Python 3.10–3.12 (`pytest.yaml`)
+- Tests run on push and PR across Python 3.10–3.14 (`pytest.yaml`)
 - Releases triggered by version tags (v*), published to PyPI (`create_artifacts_and_publish.yaml`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "cac-core>=0.7.0,<1.0.0",
+    "cac-core>=1.0.0,<2.0.0",
     "tabulate>=0.9.0",
     "jira>=3.10.5,<4.0.0",
     "pyyaml>=6.0.2",
@@ -89,6 +89,6 @@ python_classes = "Test*"
 python_functions = "test_*"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "cac-core"
-version = "0.7.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "keyring" },
@@ -111,9 +111,9 @@ dependencies = [
     { name = "requests" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/43/b335d0eb5b72d6a923629786ba67a882fe01122a11050da2daa54b07c8b3/cac_core-0.7.0.tar.gz", hash = "sha256:ab63459077ce69a0ed8b6776dccb051e739923d4b17c84f6886ed96a9db1137f", size = 103593, upload-time = "2026-03-17T18:59:03.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/f0/d2a7a662521c0bcd1b751e2896329173de8731ccf6d932402f6a0509f945/cac_core-1.0.0.tar.gz", hash = "sha256:dd246e9c35945df04298bdf1b7909de38a24c30cd0863126ccf244b7f3e77714", size = 107873, upload-time = "2026-07-14T20:43:51.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/46/ff1ca3ef411af7724c7db91a427c883b173eee8616e3af53b43e2cc44e08/cac_core-0.7.0-py3-none-any.whl", hash = "sha256:1f8c63bbc98410ca87ef3079c470d78d0d64d9ac16e1232bb9bb765b00c36dd2", size = 21854, upload-time = "2026-03-17T18:59:02.508Z" },
+    { url = "https://files.pythonhosted.org/packages/75/12/0d166a9fc2d66735fb43a471171622b64193688107cd8e81c9829518d3cc/cac_core-1.0.0-py3-none-any.whl", hash = "sha256:1b0e04a3ca1c141fd012712abb7eb6d287d7d170cdae3a2a2e2f6b97f2f2b2de", size = 26372, upload-time = "2026-07-14T20:43:50.182Z" },
 ]
 
 [[package]]
@@ -169,7 +169,7 @@ requires-dist = [
     { name = "argcomplete", specifier = ">=3.6.2" },
     { name = "black", marker = "extra == 'all'", specifier = ">=23.3,<27.0" },
     { name = "black", marker = "extra == 'lint'", specifier = ">=23.3,<27.0" },
-    { name = "cac-core", specifier = ">=0.7.0,<1.0.0" },
+    { name = "cac-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "isort", marker = "extra == 'all'", specifier = ">=5.12.0" },
     { name = "isort", marker = "extra == 'lint'", specifier = ">=5.12.0" },
     { name = "jira", specifier = ">=3.10.5,<4.0.0" },


### PR DESCRIPTION
## Summary
- Bump `cac-core` pin to `>=1.0.0,<2.0.0`. Verified API-compatible with 1.0.0: audited every cac-core API used (`logger.new`, `updatechecker.check_package_for_updates`, `config.Config`, `credentialmanager.CredentialManager`, `output.Output.print_models`, `model.Model`, `command.Command`) — all signatures unchanged. The two potentially-breaking 1.0.0 changes (`Model.__iter__` now yields keys; `Config` no longer exposes keys colliding with reserved attrs) do not affect this project. Full pytest suite, ruff, and imports pass against 1.0.0.
- Upgrade all GitHub Actions to latest SHA-pinned releases: `checkout` v7, `setup-uv` v8, `setup-python` v6, `attest-build-provenance` v4, `upload-artifact` v7, `download-artifact` v8, `pypa/gh-action-pypi-publish` v1.14.0. (None were deprecated, but all were multiple majors behind.)
- Add `.github/dependabot.yml` for the `github-actions` and `uv` ecosystems (weekly, grouped) to keep these current going forward.
- Fix stale references: mypy `python_version` 3.9 → 3.10, ruff target py39 → py310, and correct CLAUDE.md CI/CD notes (versioning is via `setuptools-scm` from git tags; there is no `version-check.yaml`).

## Testing
- `uv run pytest` → 20 passed against cac-core 1.0.0
- `uv run ruff check --target-version=py310 .` → passes

## Note
The artifact-action major bumps (`upload`/`download-artifact`) only run in the publish workflow, which triggers on release — so this PR's CI won't exercise them. Usage is the supported happy path (upload one artifact by name, download by exact name), so it should be a drop-in.