### PR TITLE
docs: refresh README and CLAUDE.md for merged CLI changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,24 @@ Command (cac_core)
 
 Each action must implement two abstract methods: `define_arguments(parser)` and `execute(args)`.
 
+### Command Execution & Error Handling
+
+`JiraCommand` uses a template method: the CLI entry point calls `command.run(args)` (a concrete method on `JiraCommand`), which invokes the subclass's `execute(args)` and maps any exception raised by the Jira client (`JIRAError` or otherwise) to a logged, non-zero exit code. Because of this:
+
+- Actions implement `execute(args)` as straight-line logic. They may let client calls raise; they do **not** need their own try/except around `JiraClient` calls.
+- `execute()` returns an int exit code — `0`/`None` for success, non-zero for the command's own validation failures (e.g. missing/invalid input, not-found guards).
+- `main()` propagates that exit code, so `$?` reflects success/failure.
+
+`JiraClient` (`cac_jira/core/client.py`) is a thin passthrough: each method returns the underlying `jira-python` result or **raises** (`JIRAError`, or `ValueError` for invalid arguments). It does not return sentinel values or swallow exceptions — the command layer decides how to present errors.
+
 ### Module Initialization
 
-`cac_jira/__init__.py` runs at import time and handles first-run setup (prompting for server, username, project) and creates three global singletons: `JIRA_CLIENT`, `CONFIG`, and `log`. These are imported by `JiraCommand` and available to all actions.
+`cac_jira/__init__.py` exposes three module-level attributes used by `JiraCommand` and all actions: `CONFIG`, `JIRA_CLIENT`, and `log`. Initialization is split and lazy (via module `__getattr__`):
+
+- `CONFIG` triggers `_initialize_config()` — loads the config file and runs first-run prompts (server, username, project). This is **network-free** and cheap, so it runs during argument parsing (including `--help`).
+- `JIRA_CLIENT` triggers `_initialize_client()` — fetches the API token and connects to Jira. This only happens the first time a command actually needs the client (i.e. at execution time), so `--help` and argument parsing work offline without credentials.
+
+`JiraCommand.__init__` loads `CONFIG` eagerly but exposes `jira_client` as a lazy property, so constructing a command (which the discovery loop does for every action) does not open a connection.
 
 ### Key Dependencies
 
@@ -62,7 +77,7 @@ Each action must implement two abstract methods: `define_arguments(parser)` and 
 1. Create a new `.py` file in the appropriate command directory (e.g., `cac_jira/commands/issue/myaction.py`)
 2. Define a class following the naming convention (e.g., `IssueMyaction`)
 3. Inherit from the command's base class (e.g., `JiraIssueCommand`)
-4. Implement `define_arguments()` and `execute()`
+4. Implement `define_arguments()` and `execute()` — `execute()` returns an exit code (`0`/`None` on success, non-zero on failure) and may let `JiraClient` calls raise; the base `run()` wrapper handles the error mapping. Do not override `run()`.
 
 ### Configuration & Credentials
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ jira <command> <action> [options]
 
 ### Global Options
 
-- `--verbose`: Enable debug output
+- `--verbose`: Enable debug output (includes a traceback for unexpected errors)
 - `--output [table|json]`: Control output format (default table)
 - `--help`: Show command help
 <!-- --suppress-output: Hide command output -->
 <!-- --version: Display version information -->
+
+Commands exit `0` on success and non-zero on failure (invalid input, a
+not-found issue/project, or a Jira API error), so they compose safely in
+scripts. `--help` and argument parsing work offline and do not require
+credentials — the Jira connection is only established when a command runs.
 
 ### Examples
 
@@ -50,10 +55,11 @@ List issues in a project:
 jira issue list --project PROJ
 ```
 
-List issues with additional filtering:
+List only issues assigned to you (and optionally include completed ones):
 
 ```bash
-jira issue list --project PROJ
+jira issue list --project PROJ --mine
+jira issue list --project PROJ --done   # include issues that are resolved
 ```
 
 Create a new issue:
@@ -102,7 +108,15 @@ Transition an issue:
 
 ```bash
 jira issue begin --issue ISSUE_KEY    # Start work
+jira issue block --issue ISSUE_KEY    # Mark as blocked
 jira issue close --issue ISSUE_KEY    # Mark as complete
+```
+
+Delete an issue (prompts for confirmation; pass `--force` to skip it, e.g. in scripts):
+
+```bash
+jira issue delete --issue ISSUE_KEY
+jira issue delete --issue ISSUE_KEY --force
 ```
 
 #### Project Commands
@@ -113,10 +127,17 @@ List all projects:
 jira project list
 ```
 
-Show a project:
+Filter projects by name or key (case-insensitive, partial match):
 
 ```bash
-jira project show --name PROJ-123
+jira project list --name "Core"
+jira project list --key COR
+```
+
+Show a single project by its key:
+
+```bash
+jira project show PROJ
 ```
 
 #### Advanced Examples
@@ -154,8 +175,6 @@ source .venv/bin/activate
 uv run pytest
 ```
 
-Please note that tests are still WIP
-
 ### Project Structure
 
 - `cac_jira/commands/` - Command implementations
@@ -168,3 +187,8 @@ Please note that tests are still WIP
 1. Create a new action module in the appropriate command directory.
 2. Define a class that inherits from the command's base class.
 3. Implement `define_arguments()` and `execute()` methods.
+
+`execute()` contains the command's logic and returns an exit code (`0`/`None`
+for success, non-zero for validation failures). It does not need to wrap Jira
+calls in try/except: the base class's `run()` wrapper catches client errors,
+logs them, and maps them to a non-zero exit code.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #46, bringing the README and CLAUDE.md in line with the merged CLI behavior and architecture.

### README.md
- **Fix `project show`** — corrected to the positional project key (`jira project show PROJ`); the old `--name PROJ-123` form no longer applies. Added `project list --name/--key` filter examples.
- **`issue list` filtering** — replaced the duplicate example with real `--mine` / `--done` usage.
- **Added `issue delete`** — documents the confirmation prompt and `--force`, plus `issue block` in the transitions list.
- **Global options** — noted `--verbose` includes tracebacks for unexpected errors, and added exit-code semantics (0 / non-zero) plus offline `--help`/parsing.
- **Dev notes** — dropped the stale "tests are still WIP" line; clarified that `execute()` returns an exit code and need not wrap Jira calls.

### CLAUDE.md
- New **Command Execution & Error Handling** section: the `run()` → `execute()` template method, the exit-code contract, and the `JiraClient` return-or-raise contract.
- **Module Initialization** rewritten for the split/lazy init (`CONFIG` eager and network-free; `JIRA_CLIENT` connects lazily), so `--help` works without credentials.
- **Adding a New Action** notes `execute()`'s return/raise contract and "don't override `run()`".

No code changes.