### PR TITLE
feat: support Personal Access Token (PAT) authentication

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  // Pin the editor's Python interpreter to the project virtualenv so Pylance
+  // resolves imports (cac_core, jira, ...) the same way the CLI pyright does
+  // (see [tool.pyright] venvPath/venv in pyproject.toml). Without this, Pylance
+  // may analyze against the wrong interpreter and report false positives such
+  // as "Cannot access attribute ... for class 'object'".
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+}

--- a/README.md
+++ b/README.md
@@ -12,16 +12,35 @@ pip install cac-jira
 
 ## Authentication
 
+cac-jira supports two authentication methods: **Basic Auth** (default) and **Personal Access Tokens (PAT)**.
+
+### Basic Auth (default)
+
 On first-run, you'll be prompted for a Jira API token; generate one [here](https://id.atlassian.com/manage-profile/security/api-tokens). This will be stored in your system credential store (e.g. Keychain on Mac OS) in an item called `cac-jira`.
+
+### Personal Access Token (PAT)
+
+Some Jira Server/Data Center instances have disabled HTTP Basic Authentication; these require Personal Access Tokens, which use `Bearer` token authentication.
+
+> **Note:** PAT authentication is only supported on Jira Server/Data Center. Jira Cloud does not support PATs — use Basic Auth with an API token instead.
+
+To use PAT authentication, set `auth_method: pat` in your config file. On the next run you'll be prompted for your PAT, which is stored in your system credential store. `username` is optional when using PAT authentication.
+
+```yaml
+server: https://your-jira-instance.example.com
+project: YOUR_PROJECT_KEY
+auth_method: pat
+```
 
 ## Configuration
 
-On first-run, a configuration file will be generated at `~/.config/cac_jira/config.yaml`. In this file you'll need to replace the values of `server` and `username` with appropriate values.
+On first-run, you'll be prompted for your `server`, `username` (basic auth only), and default `project`, and a configuration file will be generated at `~/.config/cac_jira/config.yaml`.
 
 ```yaml
 server: https://your-jira-instance.atlassian.net
 project: YOUR_PROJECT_KEY  # Optional default project
 username: your.email@example.com
+auth_method: basic  # or 'pat' for Personal Access Token
 ```
 
 ## Usage

--- a/cac_jira/__init__.py
+++ b/cac_jira/__init__.py
@@ -64,7 +64,9 @@ def _initialize_config():
             lambda v: v.replace("https://", ""),
         ),
     ]
-    if config.get("auth_method", "basic") != "pat":
+    # Normalize so "PAT"/" pat " match the same branch as "pat".
+    auth_method = (config.get("auth_method") or "basic").strip().lower()
+    if auth_method != "pat":
         keys.append(("username", "Enter your Jira username (email): ", True, None))
     keys.append(
         (
@@ -97,14 +99,19 @@ def _initialize_client():
     cac.updatechecker.check_package_for_updates(__name__)
 
     jira_server = config.get("server", "INVALID_DEFAULT").replace("https://", "")
-    auth_method = config.get("auth_method", "basic")
+    # Normalize so "PAT"/" pat " match the same branch as "pat".
+    auth_method = (config.get("auth_method") or "basic").strip().lower()
 
     credentialmanager = cac.credentialmanager.CredentialManager(__name__)
 
     if auth_method == "pat":
         # PAT (Bearer) auth: the token stands alone; username is optional and
         # the credential is stored under a fixed key rather than per-username.
+        # An unconfigured username still holds the template sentinel, so treat
+        # it as unset rather than leaking "INVALID_DEFAULT" into the client.
         jira_username = config.get("username", None)
+        if jira_username == "INVALID_DEFAULT":
+            jira_username = None
         jira_api_token = credentialmanager.get_credential(
             "_pat_token", "Jira Personal Access Token"
         )

--- a/cac_jira/__init__.py
+++ b/cac_jira/__init__.py
@@ -6,7 +6,7 @@ module docstring
 
 import sys
 from importlib import metadata
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Callable, Optional, cast
 
 import cac_core as cac
 from cac_core.cli import make_main
@@ -52,23 +52,29 @@ def _initialize_config():
     # skips prompting during shell completion (argcomplete sets ``_ARGCOMPLETE``
     # and hijacks stdio, so an interactive prompt would hang the shell); the
     # sentinel is left in place and every consumer treats it as "no value".
-    config.ensure_keys(
-        [
-            (
-                "server",
-                "Enter your Jira server URL: ",
-                True,
-                lambda v: v.replace("https://", ""),
-            ),
-            ("username", "Enter your Jira username (email): ", True, None),
-            (
-                "project",
-                "Enter your default Jira project key (optional): ",
-                False,
-                None,
-            ),
-        ]
+    #
+    # ``username`` is only required for basic auth; PAT authenticates with the
+    # token alone, so it is left out of the prompts when ``auth_method`` is
+    # ``pat`` (the user opts in by setting that key in their config file).
+    keys: list[tuple[str, str, bool, Optional[Callable[[str], str]]]] = [
+        (
+            "server",
+            "Enter your Jira server URL: ",
+            True,
+            lambda v: v.replace("https://", ""),
+        ),
+    ]
+    if config.get("auth_method", "basic") != "pat":
+        keys.append(("username", "Enter your Jira username (email): ", True, None))
+    keys.append(
+        (
+            "project",
+            "Enter your default Jira project key (optional): ",
+            False,
+            None,
+        )
     )
+    config.ensure_keys(keys)
 
     _module_state["CONFIG"] = config
 
@@ -90,23 +96,38 @@ def _initialize_client():
 
     cac.updatechecker.check_package_for_updates(__name__)
 
-    jira_username = config.get("username", "INVALID_DEFAULT")
     jira_server = config.get("server", "INVALID_DEFAULT").replace("https://", "")
+    auth_method = config.get("auth_method", "basic")
 
     credentialmanager = cac.credentialmanager.CredentialManager(__name__)
-    jira_api_token = credentialmanager.get_credential(jira_username, "Jira API key")
 
-    if not jira_api_token:
-        log.error(
-            "API token not found for %s; see https://github.com/rpunt/%s/blob/main/README.md#authentication",
-            jira_username,
-            __name__.replace("_", "-"),
+    if auth_method == "pat":
+        # PAT (Bearer) auth: the token stands alone; username is optional and
+        # the credential is stored under a fixed key rather than per-username.
+        jira_username = config.get("username", None)
+        jira_api_token = credentialmanager.get_credential(
+            "_pat_token", "Jira Personal Access Token"
         )
-        sys.exit(1)
+        if not jira_api_token:
+            log.error(
+                "Personal Access Token not found; see https://github.com/rpunt/%s/blob/main/README.md#authentication",
+                __name__.replace("_", "-"),
+            )
+            sys.exit(1)
+    else:
+        jira_username = config.get("username", "INVALID_DEFAULT")
+        jira_api_token = credentialmanager.get_credential(jira_username, "Jira API key")
+        if not jira_api_token:
+            log.error(
+                "API token not found for %s; see https://github.com/rpunt/%s/blob/main/README.md#authentication",
+                jira_username,
+                __name__.replace("_", "-"),
+            )
+            sys.exit(1)
 
     try:
         _module_state["JIRA_CLIENT"] = client.JiraClient(
-            jira_server, jira_username, jira_api_token
+            jira_server, jira_username, jira_api_token, auth_method=auth_method
         )
     except client.JiraAuthenticationError as e:
         log.error("%s", e)

--- a/cac_jira/config/cac_jira.yaml
+++ b/cac_jira/config/cac_jira.yaml
@@ -1,3 +1,4 @@
 server: INVALID_DEFAULT
 project: INVALID_DEFAULT
 username: INVALID_DEFAULT
+auth_method: basic

--- a/cac_jira/core/client.py
+++ b/cac_jira/core/client.py
@@ -28,7 +28,9 @@ class JiraClient:
     how to present errors and map them to exit codes.
     """
 
-    def __init__(self, server, username, api_token=None, auth_method="basic"):
+    def __init__(
+        self, server, username, api_token=None, auth_method: "str | None" = "basic"
+    ):
         """
         Initialize the Jira client.
 
@@ -42,7 +44,8 @@ class JiraClient:
         self.server = server
         self.username = username
         self.api_token = api_token
-        self.auth_method = auth_method
+        # Normalize so "PAT"/" pat " compare equal to "pat" downstream.
+        self.auth_method = (auth_method or "basic").strip().lower()
         self.client: jira.JIRA
         self.connect()
 
@@ -55,7 +58,9 @@ class JiraClient:
         """
         log.debug("Connecting to Jira server %s", self.server)
         if self.api_token is None:
-            raise ValueError("an API token is required to connect to Jira")
+            raise ValueError("a token is required to connect to Jira")
+        if self.auth_method != "pat" and not self.username:
+            raise ValueError("a username is required for basic authentication")
         try:
             if self.auth_method == "pat":
                 self.client = jira.JIRA(

--- a/cac_jira/core/client.py
+++ b/cac_jira/core/client.py
@@ -28,33 +28,45 @@ class JiraClient:
     how to present errors and map them to exit codes.
     """
 
-    def __init__(self, server, username, api_token=None):
+    def __init__(self, server, username, api_token=None, auth_method="basic"):
         """
         Initialize the Jira client.
 
         Args:
             server: The Jira server
             username: The Jira username
-            api_token: The Jira API token
+            api_token: The Jira API token (or Personal Access Token for ``pat``)
+            auth_method: Authentication method — ``"basic"`` (username + API
+                token) or ``"pat"`` (Bearer token, for Jira Server/Data Center)
         """
         self.server = server
         self.username = username
         self.api_token = api_token
+        self.auth_method = auth_method
         self.client: jira.JIRA
         self.connect()
 
     def connect(self):
         """
         Connect to the Jira server.
+
+        Uses ``token_auth`` (Bearer) when ``auth_method`` is ``"pat"`` and
+        ``basic_auth`` (username + API token) otherwise.
         """
         log.debug("Connecting to Jira server %s", self.server)
         if self.api_token is None:
             raise ValueError("an API token is required to connect to Jira")
         try:
-            self.client = jira.JIRA(
-                f"https://{self.server}",
-                basic_auth=(self.username, self.api_token),
-            )
+            if self.auth_method == "pat":
+                self.client = jira.JIRA(
+                    f"https://{self.server}",
+                    token_auth=self.api_token,
+                )
+            else:
+                self.client = jira.JIRA(
+                    f"https://{self.server}",
+                    basic_auth=(self.username, self.api_token),
+                )
             self.client.myself()
         except JIRAError as e:
             response = getattr(e, "response", None)

--- a/tests/test_auth_init.py
+++ b/tests/test_auth_init.py
@@ -246,6 +246,52 @@ class TestPATAuthInit:
         assert "username" not in _ensure_keys_names(mock_config)
         assert cac_jira.JIRA_CLIENT.username is None
 
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_sentinel_username_treated_as_unset(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        # An unconfigured username still holds the template sentinel; it must not
+        # leak into the client for PAT auth.
+        mock_config_class.return_value = _make_config_mock(
+            {
+                "server": "jira.example.com",
+                "auth_method": "pat",
+                "username": "INVALID_DEFAULT",
+            }
+        )
+        mock_cred_class.return_value = _make_cred_mock("pat-token-456")
+
+        cac_jira = _reimport_cac_jira()
+
+        assert cac_jira.JIRA_CLIENT.username is None
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_auth_method_normalized_selects_pat(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        # A case/whitespace-variant PAT value must select the PAT branch:
+        # username is not prompted and the credential is the PAT key.
+        mock_config = _make_config_mock(
+            {"server": "jira.example.com", "auth_method": " PAT "}
+        )
+        mock_config_class.return_value = mock_config
+        mock_cred = _make_cred_mock("pat-token-456")
+        mock_cred_class.return_value = mock_cred
+
+        cac_jira = _reimport_cac_jira()
+
+        assert "username" not in _ensure_keys_names(mock_config)
+        mock_cred.get_credential.assert_called_once_with(
+            "_pat_token", "Jira Personal Access Token"
+        )
+        assert cac_jira.JIRA_CLIENT.auth_method == "pat"
+
     @patch("cac_core.credentialmanager.CredentialManager")
     @patch("cac_core.config.Config")
     @patch("cac_core.updatechecker.check_package_for_updates")

--- a/tests/test_auth_init.py
+++ b/tests/test_auth_init.py
@@ -1,0 +1,286 @@
+"""
+Tests for auth-method branching during module initialization.
+
+These exercise ``cac_jira._initialize_config`` / ``_initialize_client`` with the
+config, credential manager, update checker, and jira client all mocked, so the
+basic-vs-PAT logic is tested in isolation from the network and the filesystem.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _reimport_cac_jira():
+    """Reset cac_jira's lazy state and re-run initialization.
+
+    State is reset in place rather than deleting the module from ``sys.modules``
+    so that other test modules (which imported command classes from cac_jira at
+    collection time) keep working — a fresh reimport would leave them bound to a
+    stale module object.
+    """
+    import cac_jira
+
+    cac_jira._module_state.clear()
+    cac_jira._initialized = False
+    cac_jira._initialize()
+    return cac_jira
+
+
+def _cleanup_cac_jira():
+    import cac_jira
+
+    cac_jira._module_state.clear()
+    cac_jira._initialized = False
+
+
+def _make_config_mock(config_dict):
+    """A mock Config whose ``get`` reads from ``config_dict``."""
+    config_dict.setdefault("project", "TEST")
+    mock_config = MagicMock()
+    mock_config.get.side_effect = lambda key, default=None: config_dict.get(
+        key, default
+    )
+    mock_config.config_file = "/mock/config"
+    return mock_config
+
+
+def _make_cred_mock(return_value):
+    mock_cred = MagicMock()
+    mock_cred.get_credential.return_value = return_value
+    return mock_cred
+
+
+def _ensure_keys_names(mock_config):
+    """The key names passed to ``config.ensure_keys`` during init."""
+    keys = mock_config.ensure_keys.call_args[0][0]
+    return [entry[0] for entry in keys]
+
+
+class TestBasicAuthInit:
+    def teardown_method(self):
+        _cleanup_cac_jira()
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_retrieves_credential_with_username(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {
+                "server": "jira.example.com",
+                "auth_method": "basic",
+                "username": "user@example.com",
+            }
+        )
+        mock_cred = _make_cred_mock("api-token-123")
+        mock_cred_class.return_value = mock_cred
+
+        _reimport_cac_jira()
+
+        mock_cred.get_credential.assert_called_once_with(
+            "user@example.com", "Jira API key"
+        )
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_creates_client_with_basic_method(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {
+                "server": "jira.example.com",
+                "auth_method": "basic",
+                "username": "user@example.com",
+            }
+        )
+        mock_cred_class.return_value = _make_cred_mock("api-token-123")
+
+        cac_jira = _reimport_cac_jira()
+
+        assert cac_jira.JIRA_CLIENT.auth_method == "basic"
+        assert cac_jira.JIRA_CLIENT.username == "user@example.com"
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_passes_basic_auth_to_jira(
+        self, _mock_update, mock_config_class, mock_cred_class, mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {
+                "server": "jira.example.com",
+                "auth_method": "basic",
+                "username": "user@example.com",
+            }
+        )
+        mock_cred_class.return_value = _make_cred_mock("api-token-123")
+
+        _reimport_cac_jira()
+
+        mock_jira.assert_called_once_with(
+            "https://jira.example.com",
+            basic_auth=("user@example.com", "api-token-123"),
+        )
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_username_is_prompted(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        mock_config = _make_config_mock(
+            {
+                "server": "jira.example.com",
+                "auth_method": "basic",
+                "username": "user@example.com",
+            }
+        )
+        mock_config_class.return_value = mock_config
+        mock_cred_class.return_value = _make_cred_mock("api-token-123")
+
+        _reimport_cac_jira()
+
+        # Basic auth includes username in the first-run prompts.
+        assert "username" in _ensure_keys_names(mock_config)
+
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_exits_on_missing_token(
+        self, _mock_update, mock_config_class, mock_cred_class
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {
+                "server": "jira.example.com",
+                "auth_method": "basic",
+                "username": "user@example.com",
+            }
+        )
+        mock_cred_class.return_value = _make_cred_mock(None)
+
+        with pytest.raises(SystemExit):
+            _reimport_cac_jira()
+
+
+class TestPATAuthInit:
+    def teardown_method(self):
+        _cleanup_cac_jira()
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_retrieves_credential_with_pat_key(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {"server": "jira.example.com", "auth_method": "pat", "username": None}
+        )
+        mock_cred = _make_cred_mock("pat-token-456")
+        mock_cred_class.return_value = mock_cred
+
+        _reimport_cac_jira()
+
+        mock_cred.get_credential.assert_called_once_with(
+            "_pat_token", "Jira Personal Access Token"
+        )
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_creates_client_with_pat_method(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {"server": "jira.example.com", "auth_method": "pat", "username": None}
+        )
+        mock_cred_class.return_value = _make_cred_mock("pat-token-456")
+
+        cac_jira = _reimport_cac_jira()
+
+        assert cac_jira.JIRA_CLIENT.auth_method == "pat"
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_passes_token_auth_to_jira(
+        self, _mock_update, mock_config_class, mock_cred_class, mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {"server": "jira.example.com", "auth_method": "pat", "username": None}
+        )
+        mock_cred_class.return_value = _make_cred_mock("pat-token-456")
+
+        _reimport_cac_jira()
+
+        mock_jira.assert_called_once_with(
+            "https://jira.example.com",
+            token_auth="pat-token-456",
+        )
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_username_not_prompted(
+        self, _mock_update, mock_config_class, mock_cred_class, _mock_jira
+    ):
+        mock_config = _make_config_mock(
+            {"server": "jira.example.com", "auth_method": "pat"}
+        )
+        mock_config_class.return_value = mock_config
+        mock_cred_class.return_value = _make_cred_mock("pat-token-456")
+
+        cac_jira = _reimport_cac_jira()
+
+        # PAT does not require a username, so it is left out of the prompts.
+        assert "username" not in _ensure_keys_names(mock_config)
+        assert cac_jira.JIRA_CLIENT.username is None
+
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_exits_on_missing_token(
+        self, _mock_update, mock_config_class, mock_cred_class
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {"server": "jira.example.com", "auth_method": "pat", "username": None}
+        )
+        mock_cred_class.return_value = _make_cred_mock(None)
+
+        with pytest.raises(SystemExit):
+            _reimport_cac_jira()
+
+
+class TestDefaultAuthMethod:
+    def teardown_method(self):
+        _cleanup_cac_jira()
+
+    @patch("jira.JIRA")
+    @patch("cac_core.credentialmanager.CredentialManager")
+    @patch("cac_core.config.Config")
+    @patch("cac_core.updatechecker.check_package_for_updates")
+    def test_defaults_to_basic_when_unset(
+        self, _mock_update, mock_config_class, mock_cred_class, mock_jira
+    ):
+        mock_config_class.return_value = _make_config_mock(
+            {"server": "jira.example.com", "username": "user@example.com"}
+        )
+        mock_cred_class.return_value = _make_cred_mock("api-token-123")
+
+        cac_jira = _reimport_cac_jira()
+
+        assert cac_jira.JIRA_CLIENT.auth_method == "basic"
+        mock_jira.assert_called_once_with(
+            "https://jira.example.com",
+            basic_auth=("user@example.com", "api-token-123"),
+        )

--- a/tests/test_auth_wire.py
+++ b/tests/test_auth_wire.py
@@ -1,0 +1,69 @@
+"""
+Wire-level auth tests: prove that JiraClient + the jira library together emit
+the correct ``Authorization`` header for each auth method.
+
+Unlike test_client.py (which mocks ``jira.JIRA`` and only checks how we call it),
+these exercise the real jira client and intercept the outgoing HTTP request at
+the transport layer (``HTTPAdapter.send``). No network or live Jira is required,
+but the assertion is on the actual header requests would put on the wire —
+Bearer for PAT, Basic for basic auth.
+"""
+
+import base64
+
+import jira.client
+import requests
+import requests.adapters
+
+from cac_jira.core.client import JiraClient
+
+
+def _capture_authorization(monkeypatch, username, token, auth_method):
+    """Build a JiraClient and return the Authorization header of the first
+    HTTP request the jira client actually sends."""
+    captured = {}
+
+    def fake_send(self, request, **kwargs):
+        captured.setdefault("authorization", request.headers.get("Authorization"))
+        resp = requests.models.Response()
+        resp.status_code = 200
+        # Superset payload that satisfies both serverInfo and myself parsing.
+        resp._content = (
+            b'{"version": "9.4.0", "versionNumbers": [9, 4, 0], '
+            b'"deploymentType": "Server", "accountId": "123", '
+            b'"name": "tester", "key": "tester"}'
+        )
+        resp.headers["Content-Type"] = "application/json"
+        resp.encoding = "utf-8"
+        resp.url = request.url
+        resp.request = request
+        return resp
+
+    # conftest globally mocks ``jira.JIRA``; restore the real client (still
+    # available at jira.client.JIRA) so an actual request is built and sent.
+    monkeypatch.setattr("jira.JIRA", jira.client.JIRA)
+
+    # Patch the base transport adapter so every request (including any made
+    # inside jira.JIRA.__init__) is intercepted, regardless of jira's custom
+    # session/retry wrapper.
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", fake_send)
+
+    JiraClient("jira.example.com", username, token, auth_method=auth_method)
+    return captured["authorization"]
+
+
+def test_pat_sends_bearer_authorization(monkeypatch):
+    auth = _capture_authorization(
+        monkeypatch, None, "PAT-secret-123", auth_method="pat"
+    )
+    assert auth == "Bearer PAT-secret-123"
+
+
+def test_basic_sends_basic_authorization(monkeypatch):
+    auth = _capture_authorization(
+        monkeypatch, "user@example.com", "api-token-123", auth_method="basic"
+    )
+    assert auth is not None
+    assert auth.startswith("Basic ")
+    decoded = base64.b64decode(auth.split(" ", 1)[1]).decode()
+    assert decoded == "user@example.com:api-token-123"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,3 +131,28 @@ class TestJiraClientAuthMethods:
 
         assert client.auth_method == "pat"
         assert client.username is None
+
+    def test_auth_method_is_normalized(self, mock_jira_class):
+        # A case/whitespace-variant PAT value must still select token_auth.
+        client = JiraClient("jira.example.com", None, "pat-token", auth_method=" PAT ")
+
+        assert client.auth_method == "pat"
+        mock_jira_class.assert_called_once_with(
+            "https://jira.example.com",
+            token_auth="pat-token",
+        )
+
+    def test_none_auth_method_defaults_to_basic(self, mock_jira_class):
+        client = JiraClient(
+            "jira.example.com", "user@example.com", "api-token", auth_method=None
+        )
+
+        assert client.auth_method == "basic"
+
+    def test_basic_auth_requires_username(self, mock_jira_class):
+        with pytest.raises(ValueError, match="username is required"):
+            JiraClient("jira.example.com", None, "api-token")
+
+    def test_missing_token_raises(self, mock_jira_class):
+        with pytest.raises(ValueError, match="token is required"):
+            JiraClient("jira.example.com", "user@example.com", None)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,3 +92,42 @@ class TestJiraClientAddLabels:
 
         with pytest.raises(JIRAError):
             client.add_labels("TEST-1", "bug")
+
+
+@patch("jira.JIRA")
+class TestJiraClientAuthMethods:
+    """The auth_method flag selects basic_auth vs token_auth at connect time."""
+
+    def test_basic_auth_uses_basic_auth_param(self, mock_jira_class):
+        JiraClient("jira.example.com", "user@example.com", "api-token-123")
+
+        mock_jira_class.assert_called_once_with(
+            "https://jira.example.com",
+            basic_auth=("user@example.com", "api-token-123"),
+        )
+
+    def test_pat_auth_uses_token_auth_param(self, mock_jira_class):
+        JiraClient("jira.example.com", None, "pat-token-456", auth_method="pat")
+
+        mock_jira_class.assert_called_once_with(
+            "https://jira.example.com",
+            token_auth="pat-token-456",
+        )
+
+    def test_pat_auth_omits_basic_auth(self, mock_jira_class):
+        JiraClient(
+            "jira.example.com",
+            "user@example.com",
+            "pat-token-456",
+            auth_method="pat",
+        )
+
+        call_kwargs = mock_jira_class.call_args[1]
+        assert "basic_auth" not in call_kwargs
+        assert call_kwargs["token_auth"] == "pat-token-456"
+
+    def test_auth_method_and_username_stored(self, mock_jira_class):
+        client = JiraClient("jira.example.com", None, "pat-token", auth_method="pat")
+
+        assert client.auth_method == "pat"
+        assert client.username is None


### PR DESCRIPTION
Closes #20.

## Summary

Adds a second authentication method for **Jira Server/Data Center** instances that have HTTP Basic Auth disabled and require Personal Access Tokens (Bearer auth). Basic auth remains the default, so existing setups are unaffected.

This is a clean re-implementation of the stale `20-support-personal-access-tokens` branch (which was ~44 commits behind and written against the pre–cac-core-2.0 `_initialize()`), rebuilt on top of the current lazy-init structure and the typed `JiraClient`.

## How it works

- **Config** — new `auth_method` key (defaults to `basic`). Set `auth_method: pat` in `~/.config/cac_jira/config.yaml` to opt in.
- **`client.py`** — `JiraClient` gains an `auth_method` argument and connects with `token_auth=<PAT>` for PAT vs `basic_auth=(username, api_token)` for basic.
- **`__init__.py`** —
  - `_initialize_config` omits the `username` prompt when `auth_method: pat` (the token authenticates on its own; username stays optional).
  - `_initialize_client` retrieves the PAT from the credential store under a fixed `_pat_token` key and passes `auth_method` through to the client.
- **README** — documents Basic vs PAT, with the Cloud-vs-Server caveat.

## Tests
- `tests/test_client.py` — new `TestJiraClientAuthMethods`: basic→`basic_auth`, pat→`token_auth`, PAT omits `basic_auth`, attrs stored.
- `tests/test_auth_init.py` (new) — init-time branching for basic/pat/default: credential-key selection, client `auth_method`, jira call kwargs, username prompted (basic) vs omitted (pat), and `SystemExit` on missing token. State is reset in place (not via `sys.modules` deletion) to avoid cross-test pollution.

## Verification (local, mirrors CI)
| Check | Result |
|---|---|
| `pyright` | 0 errors, 0 warnings |
| `ruff check` / `format --diff` | clean |
| `pytest` + coverage | 115 passed, 94.04% (gate 90%) |
| smoke | `jira --help` loads offline; PAT→`token_auth`, basic→`basic_auth` confirmed |