### PR TITLE
chore: strip vestigial shebangs from library modules

### DIFF
--- a/cac_jira/commands/command.py
+++ b/cac_jira/commands/command.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Base class for all Jira CLI commands.
 

--- a/cac_jira/commands/issue/__init__.py
+++ b/cac_jira/commands/issue/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Base module for all issue-related commands.
 

--- a/cac_jira/commands/issue/attach.py
+++ b/cac_jira/commands/issue/attach.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=line-too-long, import-outside-toplevel, broad-exception-caught
 
 """

--- a/cac_jira/commands/issue/browse.py
+++ b/cac_jira/commands/issue/browse.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=line-too-long, import-outside-toplevel, broad-exception-caught
 
 """

--- a/cac_jira/commands/issue/create.py
+++ b/cac_jira/commands/issue/create.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=line-too-long, import-outside-toplevel, broad-exception-caught
 
 """

--- a/cac_jira/commands/issue/fields.py
+++ b/cac_jira/commands/issue/fields.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=line-too-long, import-outside-toplevel, broad-exception-caught
 
 """

--- a/cac_jira/commands/issue/list.py
+++ b/cac_jira/commands/issue/list.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=line-too-long
 
 """

--- a/cac_jira/commands/issue/show.py
+++ b/cac_jira/commands/issue/show.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=line-too-long, import-outside-toplevel, broad-exception-caught
 
 """

--- a/cac_jira/commands/project/__init__.py
+++ b/cac_jira/commands/project/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=import-outside-toplevel
 """
 

--- a/cac_jira/commands/project/show.py
+++ b/cac_jira/commands/project/show.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Command module for showing a single Jira project.
 """

--- a/cac_jira/core/client.py
+++ b/cac_jira/core/client.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # pylint: disable=no-member
 
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Test script for the Jira CLI implementation.
 


### PR DESCRIPTION
## What

Removes the `#!/usr/bin/env python` shebang line from all library modules and test files that carried one (and any resulting leading blank line).

## Why

These files are imported as library modules — the `jira` command is exposed via the `cac_jira:main` console-script entry point, not by executing any module directly. The shebangs were vestigial.

ruff 0.16.0 (see #54) enables `EXE001` in its default rule set, which flags a shebang present on a non-executable file. The correct fix is to remove the shebangs rather than `chmod +x` modules that aren't meant to run standalone. This unblocks the ruff bump in #54.

## Verification

- `ruff check --select EXE .` → clean
- `ruff format --diff .` → no changes
- `uv run pytest` → 123 passed
- `import cac_jira` → ok