### PR TITLE
chore: resolve ruff 0.16.0 default-rule findings

### DIFF
--- a/cac_jira/__init__.py
+++ b/cac_jira/__init__.py
@@ -1,12 +1,13 @@
-# pylint: disable=broad-except, line-too-long
+# pylint: disable=line-too-long
 
 """
 module docstring
 """
 
 import sys
+from collections.abc import Callable
 from importlib import metadata
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 import cac_core as cac
 from cac_core.cli import make_main
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 
 try:
     __version__ = metadata.version(__name__)
-except Exception:
+except metadata.PackageNotFoundError:
     __version__ = "#N/A"
 
 log = cac.logger.new(__name__)
@@ -56,7 +57,7 @@ def _initialize_config():
     # ``username`` is only required for basic auth; PAT authenticates with the
     # token alone, so it is left out of the prompts when ``auth_method`` is
     # ``pat`` (the user opts in by setting that key in their config file).
-    keys: list[tuple[str, str, bool, Optional[Callable[[str], str]]]] = [
+    keys: list[tuple[str, str, bool, Callable[[str], str] | None]] = [
         (
             "server",
             "Enter your Jira server URL: ",
@@ -173,4 +174,4 @@ def __getattr__(name):
 main = make_main("cac_jira", "jira", "Jira CLI tool")
 
 
-__all__ = ["JIRA_CLIENT", "CONFIG", "log", "main", "_initialize"]
+__all__ = ["CONFIG", "JIRA_CLIENT", "_initialize", "log", "main"]

--- a/cac_jira/commands/command.py
+++ b/cac_jira/commands/command.py
@@ -7,7 +7,6 @@ command actions.
 """
 
 import abc
-from typing import Optional
 
 from cac_core.command import Command
 from jira.exceptions import JIRAError
@@ -38,7 +37,7 @@ class JiraCommand(Command):
         super().__init__()
         self.log = log
         self.config = cac_jira.CONFIG
-        self._jira_client: Optional[JiraClient] = None
+        self._jira_client: JiraClient | None = None
 
     @property
     def jira_client(self) -> JiraClient:

--- a/cac_jira/commands/issue/__init__.py
+++ b/cac_jira/commands/issue/__init__.py
@@ -98,7 +98,7 @@ class JiraIssueCommand(JiraCommand):
                 self.log.info('Added comment: "%s"', comment)
             self.log.info('Issue %s transitioned to "%s"', issue.key, matched_name)
             return True
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             self.log.error("Failed to transition issue: %s", str(e))
             return False
 

--- a/cac_jira/commands/issue/create.py
+++ b/cac_jira/commands/issue/create.py
@@ -305,7 +305,7 @@ class IssueCreate(JiraIssueCommand):
                 # Execute the begin command with our constructed args (through
                 # the error-handling wrapper) and propagate its exit code.
                 begin_result = begin_cmd.run(begin_args) or 0
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                 self.log.error("Failed to transition issue to In Progress: %s", str(e))
                 begin_result = 1
 

--- a/cac_jira/commands/issue/fields.py
+++ b/cac_jira/commands/issue/fields.py
@@ -57,7 +57,7 @@ class IssueFields(JiraIssueCommand):
             for field_id, field in issuetype_meta["fields"].items():
                 if field.get("required", False):
                     allowed = ""
-                    if "allowedValues" in field and field["allowedValues"]:
+                    if field.get("allowedValues"):
                         values = [
                             v.get("name", v.get("value", "Unknown"))
                             for v in field["allowedValues"][:5]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,13 +91,13 @@ def main_test():
     try:
         # Test using the CLI main function
         test_cli_direct()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Error testing via CLI main(): {e}")
 
     try:
         # Test using direct class instantiation
         test_command_classes()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"Error testing via direct class instantiation: {e}")
 
     print("\nTest completed.")

--- a/tests/test_init_integration.py
+++ b/tests/test_init_integration.py
@@ -105,6 +105,7 @@ class TestClientInitErrors:
 
     def test_missing_token_exits(self, reset_client_state, monkeypatch):
         import cac_core as cac
+
         import cac_jira
 
         # No stored credential and no prompt -> hard exit with a clear message.
@@ -119,6 +120,7 @@ class TestClientInitErrors:
 
     def test_authentication_error_exits(self, reset_client_state, monkeypatch):
         import cac_core as cac
+
         import cac_jira
         from cac_jira.core import client
 

--- a/tests/test_main_exit.py
+++ b/tests/test_main_exit.py
@@ -17,17 +17,21 @@ class TestMainExitCodes:
     def test_nonzero_return_causes_exit(self, monkeypatch):
         """A truthy return value from execute() becomes the process exit code."""
         monkeypatch.setattr(sys, "argv", ["jira", "issue", "show", "-i", "TEST-1"])
-        with patch.object(IssueShow, "execute", return_value=1):
-            with pytest.raises(SystemExit) as exc:
-                main()
+        with (
+            patch.object(IssueShow, "execute", return_value=1),
+            pytest.raises(SystemExit) as exc,
+        ):
+            main()
         assert exc.value.code == 1
 
     def test_exception_causes_exit(self, monkeypatch):
         """An exception raised by execute() results in a non-zero exit."""
         monkeypatch.setattr(sys, "argv", ["jira", "issue", "show", "-i", "TEST-1"])
-        with patch.object(IssueShow, "execute", side_effect=RuntimeError("boom")):
-            with pytest.raises(SystemExit) as exc:
-                main()
+        with (
+            patch.object(IssueShow, "execute", side_effect=RuntimeError("boom")),
+            pytest.raises(SystemExit) as exc,
+        ):
+            main()
         assert exc.value.code == 1
 
     def test_success_does_not_exit(self, monkeypatch):


### PR DESCRIPTION
## What

Resolves the remaining lint findings introduced by ruff 0.16.0's expanded default rule set (413 rules, up from 59 — see #54). Follows #55 (shebang removal / EXE001).

| Rule | Fix |
|------|-----|
| `UP035` | import `Callable` from `collections.abc` |
| `UP045` | `Optional[X]` → `X \| None` (dropped now-unused `Optional` imports) |
| `RUF022` | sort `__all__` |
| `RUF019` | `field.get("allowedValues")` instead of `"allowedValues" in field and field[...]` |
| `I001` | sort import blocks in tests |
| `SIM117` | combine nested `with` statements in tests |
| `BLE001` | narrow version lookup to `PackageNotFoundError`; `# noqa: BLE001` on the intentional log-and-continue catch-alls |

## Notes

- `BLE001`: the version-lookup catch was narrowed to `metadata.PackageNotFoundError` (the only exception `metadata.version` raises). The other four are deliberate log-and-continue catch-alls in CLI actions / test harnesses, so they're explicitly marked `# noqa: BLE001` rather than narrowed.
- Removed the now-redundant `broad-except` pylint disable from `cac_jira/__init__.py`.

## Verification

- `ruff 0.16.0 check .` → **All checks passed**
- `ruff 0.16.0 format --diff .` → no changes
- `uv run pytest` → 123 passed
- `uv run pyright` → 0 errors

After this lands, the ruff bump in #54 should go green on rebase.